### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,9 +1,8 @@
 ---
 - name: debian | Installing NFS Client Packages
   apt:
-    name: "{{ item }}"
+    name:
+      - 'nfs-common'
+      - 'rpcbind'
     state: "present"
   become: true
-  with_items:
-    - 'nfs-common'
-    - 'rpcbind'


### PR DESCRIPTION
Ansible started throwing following deprecation warning:

```
TASK [nfs-client : debian | Installing NFS Client Packages] ********************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: {{ item }}`, please use `name: [u'nfs-common', 
u'rpcbind']` and remove the loop. This feature will be removed in version 2.11.
```

This PR should fix that.