### PR TITLE
Replace deprecated include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # tasks file for ansible-nfs-client
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include: redhat.yml
+- include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
 
-- include: config.yml
+- import_tasks: config.yml


### PR DESCRIPTION
This is now deprecated and will be removed in future versions of
Ansible:

```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks
instead. This feature will be removed in version 2.16. Deprecation warnings can
 be disabled by setting deprecation_warnings=False in ansible.cfg.
```

I've replaced the use of `include` with dynamic `include_tasks` and
static `import_tasks` as appropriate.